### PR TITLE
bugfix: removal of hardcoded region and added extra configurations to cloudwatch log group

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -165,3 +165,13 @@ variable "assign_public_ip" {
   type        = bool
   description = "Configures ECS Service to assign public IP (Fargate Only)"
 }
+
+variable "cloudwatch_logs_retention" {
+  default     = 120
+  description = "Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
+}
+
+variable "cloudwatch_logs_export" {
+  default     = false
+  description = "Whether to mark the log group to export to an S3 bucket (needs terraform-aws-log-exporter to be deployed in the account/region)"
+}

--- a/cloudwatch-logs.tf
+++ b/cloudwatch-logs.tf
@@ -1,3 +1,7 @@
 resource "aws_cloudwatch_log_group" "default" {
-  name = "/ecs/${var.cluster_name}/${var.name}"
+  name              = "/ecs/${var.cluster_name}/${var.name}"
+  retention_in_days = var.cloudwatch_logs_retention
+  tags = {
+    ExportToS3 = var.cloudwatch_logs_export
+  }
 }

--- a/ecs-task-definition.tf
+++ b/ecs-task-definition.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "default" {
       "log_driver": "awslogs",
       "options": {
           "awslogs-group": "${aws_cloudwatch_log_group.default.arn}",
-          "awslogs-region": "ap-southeast-2",
+          "awslogs-region": "${data.aws_region.current.name}",
           "awslogs-stream-prefix": "app"
       }
     }


### PR DESCRIPTION
Removes the `ap-southeast-2` hard-coded region in ECS task definition. And adds `retention_in_days` and `ExportToS3` tag to the CloudWatch log group.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)